### PR TITLE
allow robots to crawl /web-a11y-guidance/ gh-pages

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
+Allow: /web-a11y-guidance/
 Disallow: /
-


### PR DESCRIPTION
The site at https://govtnz.github.io/web-a11y-guidance/ is public now and it makes sense for it to be available via search engines. But still want to disallow crawling other GOVTNZ repos using gh-pages.  As I understand it, the robots.txt order of precedence for rules will apply and respect the Allow rule, and then Disallow otherwise everything. 