### PR TITLE
Fixed broken link to Digital Govt site

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 		</header>
 		<main>
 			<h1>New Zealand Government on GitHub</h1>
-			<p>Repositories for work related to <a href="https://www.govt.nz/">Govt.nz</a> and <a href="https://www.digital.govt.,nz/">Digital.govt.nz</a>, the <a href="web-standards/">NZ Government Web Standards</a>, the <a href="web-a11y-guidance/">Web Accessibility Guidance project</a>, and more.</p>
+			<p>Repositories for work related to <a href="https://www.govt.nz/">Govt.nz</a> and <a href="https://www.digital.govt.nz/">Digital.govt.nz</a>, the <a href="web-standards/">NZ Government Web Standards</a>, the <a href="web-a11y-guidance/">Web Accessibility Guidance project</a>, and more.</p>
 		</main>
 		<footer>
 			<div class="logos"><a href="https://www.dia.govt.nz/"><span class="visually-hidden"><span lang="mi">Te Tari Taiwhenua</span>/</span><img src="common/img/dia-logo-white-black.png" alt="Department of Internal Affairs" width="252" height="72"></a></div>


### PR DESCRIPTION
Removed comma from link to fix link to digital.govt.nz website.